### PR TITLE
Fix scr1, ariane to use synthesizable tops

### DIFF
--- a/generators/ariane
+++ b/generators/ariane
@@ -105,6 +105,9 @@ while (components := next(ver_cmd_comp_iter, False)):
         if 'axi2apb_wrap.sv' not in args and args not in sources:
             sources.append(os.path.join(ariane_path, args))
 
+# Override top module
+top_module = "cva6"
+
 os.chdir(main_path)
 test_dir = os.path.join(tests_dir, 'generated', tests_subdir)
 

--- a/generators/scr1
+++ b/generators/scr1
@@ -18,7 +18,7 @@ templ = """/*
 :files: {0}
 :incdirs: {1}
 :tags: scr1
-:top_module: scr1_top_tb_axi
+:top_module: scr1_top_axi
 :results_group: cores
 :timeout: 100
 */


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Override top module to `cva6` in `ariane` and change top module to `scr1_top_axi` in `scr1`.
> 
>   - **Behavior**:
>     - In `generators/ariane`, override top module to `cva6`.
>     - In `generators/scr1`, change top module from `scr1_top_tb_axi` to `scr1_top_axi`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2Fsv-tests&utm_source=github&utm_medium=referral)<sup> for 5dfc13530e05bc45e2339444b5d8288ecdfd1fe2. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->