### PR TITLE
Add clang dependency to CI for VlogHammer tests

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -16,19 +16,19 @@ jobs:
       matrix:
         tool:
           - name: icarus
-            deps: autoconf autotools-dev bison flex libfl-dev gperf
+            deps: autoconf autotools-dev bison flex libfl-dev gperf clang
           - name: slang
-            deps: cmake pkg-config
+            deps: cmake pkg-config clang
           # - name: surelog
           #   repo: Surelog
           #   submodules: third_party/UHDM third_party/antlr4 third_party/googletest
           #   deps: cmake default-jre pkg-config tclsh uuid-dev
           - name: verible
-            deps: bazel=7.6.1 bison flex libfl-dev
+            deps: bazel=7.6.1 bison flex libfl-dev clang
             runners_filter: Verible
             skip-ccache: 1
           - name: verilator
-            deps: autoconf autotools-dev bison flex help2man libfl-dev libelf-dev
+            deps: autoconf autotools-dev bison flex help2man libfl-dev libelf-dev clang
             make_jobs_max: 4
           - name: yosys
             deps: bison clang tcl-dev flex libfl-dev pkg-config libreadline-dev


### PR DESCRIPTION
add clang to `./github/workflow/sv-tests-ci`  as dependency required by `vlogHammer`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `clang` dependency to CI for `vlogHammer` tests in `sv-tests-ci.yml`.
> 
>   - **CI Configuration**:
>     - Add `clang` to dependencies for `icarus`, `slang`, `verible`, and `verilator` in `sv-tests-ci.yml`.
>     - Ensures `vlogHammer` tests have necessary dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2Fsv-tests&utm_source=github&utm_medium=referral)<sup> for 58b7d9241d3d7c77f41bfbe03e70b90a72d8c5fd. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->