### PR TITLE
Adding chimera tests

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -288,6 +288,7 @@ jobs:
       - name: Find artifacts that are no longer needed
         id: get-artifacts-to-delete
         if: github.event_name == 'pull_request'
+        shell: bash
         run: |
           artifacts=$(find ./out -type d -name 'report_*' -exec basename {} \;)
           echo $artifacts

--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         tool:
           - name: icarus
-            deps: autoconf autotools-dev bison flex libfl-dev gperf clang cmake
+            deps: autoconf autotools-dev bison flex libfl-dev gperf clang
           - name: slang
             deps: cmake pkg-config clang
           # - name: surelog
@@ -24,14 +24,14 @@ jobs:
           #   submodules: third_party/UHDM third_party/antlr4 third_party/googletest
           #   deps: cmake default-jre pkg-config tclsh uuid-dev
           - name: verible
-            deps: bazel=7.6.1 bison flex libfl-dev clang cmake
+            deps: bazel=7.6.1 bison flex libfl-dev clang
             runners_filter: Verible
             skip-ccache: 1
           - name: verilator
-            deps: autoconf autotools-dev bison flex help2man libfl-dev libelf-dev clang cmake
+            deps: autoconf autotools-dev bison flex help2man libfl-dev libelf-dev clang
             make_jobs_max: 4
           - name: yosys
-            deps: bison clang tcl-dev flex libfl-dev pkg-config libreadline-dev cmake
+            deps: bison clang tcl-dev flex libfl-dev pkg-config libreadline-dev
           - name: yosys-slang
             deps: bison clang tcl-dev flex libfl-dev pkg-config libreadline-dev cmake pkg-config
             submodules: third_party/slang third_party/fmt
@@ -218,7 +218,7 @@ jobs:
       - name: Setup python
         run: |
           apt-get update -qq
-          apt install -y python3 python3-pip wget git curl jq cmake 
+          apt install -y python3 python3-pip wget git curl jq 
           pip install --break-system-packages --upgrade setuptools
           pip install --break-system-packages -r conf/requirements.txt
       - name: Install VeeR dependencies

--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         tool:
           - name: icarus
-            deps: autoconf autotools-dev bison flex libfl-dev gperf clang cmake 
+            deps: autoconf autotools-dev bison flex libfl-dev gperf clang cmake
           - name: slang
             deps: cmake pkg-config clang
           # - name: surelog

--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -218,7 +218,7 @@ jobs:
       - name: Setup python
         run: |
           apt-get update -qq
-          apt install -y python3 python3-pip wget git curl jq 
+          apt install -y python3 python3-pip wget git curl jq
           pip install --break-system-packages --upgrade setuptools
           pip install --break-system-packages -r conf/requirements.txt
       - name: Install VeeR dependencies

--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         tool:
           - name: icarus
-            deps: autoconf autotools-dev bison flex libfl-dev gperf clang
+            deps: autoconf autotools-dev bison flex libfl-dev gperf clang cmake 
           - name: slang
             deps: cmake pkg-config clang
           # - name: surelog
@@ -24,14 +24,14 @@ jobs:
           #   submodules: third_party/UHDM third_party/antlr4 third_party/googletest
           #   deps: cmake default-jre pkg-config tclsh uuid-dev
           - name: verible
-            deps: bazel=7.6.1 bison flex libfl-dev clang
+            deps: bazel=7.6.1 bison flex libfl-dev clang cmake
             runners_filter: Verible
             skip-ccache: 1
           - name: verilator
-            deps: autoconf autotools-dev bison flex help2man libfl-dev libelf-dev clang
+            deps: autoconf autotools-dev bison flex help2man libfl-dev libelf-dev clang cmake
             make_jobs_max: 4
           - name: yosys
-            deps: bison clang tcl-dev flex libfl-dev pkg-config libreadline-dev
+            deps: bison clang tcl-dev flex libfl-dev pkg-config libreadline-dev cmake
           - name: yosys-slang
             deps: bison clang tcl-dev flex libfl-dev pkg-config libreadline-dev cmake pkg-config
             submodules: third_party/slang third_party/fmt
@@ -218,7 +218,7 @@ jobs:
       - name: Setup python
         run: |
           apt-get update -qq
-          apt install -y python3 python3-pip wget git curl jq
+          apt install -y python3 python3-pip wget git curl jq cmake 
           pip install --break-system-packages --upgrade setuptools
           pip install --break-system-packages -r conf/requirements.txt
       - name: Install VeeR dependencies

--- a/.gitmodules
+++ b/.gitmodules
@@ -87,3 +87,6 @@
 [submodule "third_party/tools/verilator"]
 	path = third_party/tools/verilator
 	url = https://github.com/verilator/verilator
+[submodule "third_party/tests/chimera"]
+	path = third_party/tests/chimera
+	url = https://github.com/Silimate/chimera.git

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ RUNNERS := $(sort $(shell OUT_DIR=$(OUT_DIR) RUNNERS_DIR=$(RUNNERS_DIR) \
                           TREE_SITTER_SVERILOG_PARSER_DIR=$(TREE_SITTER_SVERILOG_PARSER_DIR) \
                           TREE_SITTER_VERILOG_PARSER_DIR=$(TREE_SITTER_VERILOG_PARSER_DIR) \
 			  ./tools/check-runners $(RUNNERS_FOUND) $(FILTER)))
-TESTS := $(shell find $(TESTS_DIR) -type f -iname *.sv)
+TESTS := $(shell find $(TESTS_DIR) -type f \( -iname "*.sv" -o -iname "*.v" \))
 TESTS := $(TESTS:$(TESTS_DIR)/%=%)
 GENERATORS := $(wildcard $(GENERATORS_DIR)/*)
 GENERATORS := $(GENERATORS:$(GENERATORS_DIR)/%=%)

--- a/conf/lrm.conf
+++ b/conf/lrm.conf
@@ -29,6 +29,7 @@ rsd	RSD RISC-V core	https://github.com/rsd-devel/rsd
 ivtest	Tests imported from ivtest	https://github.com/steveicarus/iverilog/tree/master/ivtest
 RgGen	RgGen code generator for configuration and status registers	https://github.com/rggen/rggen
 TNoC	NoC router and fabric	https://github.com/taichi-ishitani/tnoc
+Chimera	Tests imported from chimera	https://github.com/Silimate/chimera
 5	Lexical conventions
 5.1	General
 5.2	Lexical tokens

--- a/generators/chimera
+++ b/generators/chimera
@@ -64,7 +64,7 @@ def ChiBench():
             dest_file.write(content)
 
         count += 1
-    print(f"Copied {count} ChiGen tests to {output_dir}")
+    print(f"Copied {count} ChiBench tests to {output_dir}")
 
 
 def ChiGen():

--- a/generators/chimera
+++ b/generators/chimera
@@ -20,8 +20,8 @@ except KeyError:
     print("Export the TESTS_DIR and THIRD_PARTY_DIR variables first")
     sys.exit(1)
 
-ChiGen = True
-ChiBench = True
+run_ChiGen = True
+run_ChiBench = True
 
 header_ChiGen = """/*
 :name: {name}
@@ -156,8 +156,8 @@ def ChiGen():
     print(f"Done. Success: {success}, Failed: {failed}")
 
 
-if (ChiGen):
+if (run_ChiGen):
     ChiGen()
 
-if (ChiBench):
+if (run_ChiBench):
     ChiBench()

--- a/generators/chimera
+++ b/generators/chimera
@@ -8,10 +8,10 @@
 # https://opensource.org/licenses/ISC
 #
 # SPDX-License-Identifier: ISC
-
 import os
 import sys
 import subprocess
+import glob
 
 try:
     tests_dir = os.environ['TESTS_DIR']
@@ -20,73 +20,141 @@ except KeyError:
     print("Export the TESTS_DIR and THIRD_PARTY_DIR variables first")
     sys.exit(1)
 
+ChiGen = True
+ChiBench = True
+
 subdir = 'chimera'
 
 chimera_root = os.path.join(third_party_dir, 'tests', 'chimera')
-
-build_dir = os.path.join(chimera_root, 'build')
-chimera_bin = os.path.join(chimera_root, 'build', 'Chimera')
-
-if not os.path.exists(chimera_bin):
-    print("Chimera binary not found. Building Chimera...")
-
-    os.makedirs(build_dir, exist_ok=True)
-
-    try:
-        subprocess.check_call(['cmake', '../src'], cwd=build_dir)
-        subprocess.check_call(['make', 'Chimera'], cwd=build_dir)
-        print("Chimera built successfully.")
-    except subprocess.CalledProcessError as e:
-        print(f"Error building Chimera: {e}")
-        sys.exit(1)
-else:
-    print(f"Chimera binary found at {chimera_bin}")
 output_dir = os.path.join(tests_dir, 'generated', subdir)
-os.makedirs(output_dir, exist_ok=True)
-
-print(f"Generating tests in {output_dir}...")
 
 
+def ChiBench():
 
-success = 0
-failed = 0
+    header_templ = """/*
+    :name: {name}
+    :description: Imported test case from ChiBench
+    :tags: chimera
+    :type: parsing
+    */
+    """
+    limit = 5
+    count = 0
+    for f in glob.glob(os.path.join(chimera_root, "3k_programs_for_bugs",
+                                    "chibench", '*.v')):
+        if count >= limit:
+            break
 
-json_files = os.listdir(os.path.join(chimera_root, 'json'))
-json_files.sort()
+        filename = os.path.basename(f)
+        test_name = os.path.splitext(filename)[0]
+        output_file = os.path.join(output_dir, test_name + '.v')
+        with open(f, 'r') as source_file:
+            content = source_file.read()
+        with open(output_file, "w") as dest_file:
+            dest_file.write(header_templ.format(name=test_name))
+            dest_file.write(content)
 
-for json_file in json_files:
-    print(f"  genrating test for {chimera_root}/{json_file} grammer file")
-    test_name = f"chimera_{json_file}"
-    filename = os.path.join(output_dir, f"{test_name}.sv")
+        count += 1
+    print(f"Copied {count} ChiGen tests to {output_dir}")
 
-    cmd = [chimera_bin, os.path.join(chimera_root, 'json', json_file), "1"]
 
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True)
+def ChiGen():
 
-        if result.returncode != 0:
-            print(f"    Test for {json_file} failed to generate")
+    header_templ = """/*
+    :name: {name}
+    :description: Imported test case from ChiGen
+    :tags: chimera
+    :type: parsing
+    */
+    """
+    limit = 5
+    count = 0
+    for f in glob.glob(os.path.join(chimera_root, "3k_programs_for_bugs",
+                                    "chigen", '*.v')):
+        if count >= limit:
+            break
+
+        filename = os.path.basename(f)
+        test_name = os.path.splitext(filename)[0]
+        output_file = os.path.join(output_dir, test_name + '.v')
+        with open(f, 'r') as source_file:
+            content = source_file.read()
+        with open(output_file, "w") as dest_file:
+            dest_file.write(header_templ.format(name=test_name))
+            dest_file.write(content)
+
+        count += 1
+    print(f"Copied {count} ChiGen tests to {output_dir}")
+    build_dir = os.path.join(chimera_root, 'build')
+    chimera_bin = os.path.join(chimera_root, 'build', 'Chimera')
+
+    return  # skiping the manual genration
+
+    if not os.path.exists(chimera_bin):
+        print("Chimera binary not found. Building Chimera...")
+
+        os.makedirs(build_dir, exist_ok=True)
+
+        try:
+            subprocess.check_call(['cmake', '../src'], cwd=build_dir)
+            subprocess.check_call(['make', 'Chimera'], cwd=build_dir)
+            print("Chimera built successfully.")
+        except subprocess.CalledProcessError as e:
+            print(f"Error building Chimera: {e}")
+            sys.exit(1)
+    else:
+        print(f"Chimera binary found at {chimera_bin}")
+    os.makedirs(output_dir, exist_ok=True)
+
+    print(f"ChiGen : Generating tests in {output_dir}...")
+
+    success = 0
+    failed = 0
+
+    json_files = os.listdir(os.path.join(chimera_root, 'json'))
+    json_files.sort()
+    json_files = json_files[0:1]  # as genration take time this for now
+
+    for json_file in json_files:
+        print(f"  genrating test for {chimera_root}/{json_file} grammer file")
+        test_name = f"ChiGen_{json_file}"
+        filename = os.path.join(output_dir, f"{test_name}.sv")
+
+        cmd = [chimera_bin, os.path.join(chimera_root, 'json', json_file), "1"]
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True)
+
+            if result.returncode != 0:
+                print(f"    Test for {json_file} failed to generate")
+                failed += 1
+                continue
+
+            verilog_code = result.stdout
+
+            header = (
+                "/*\n"
+                f":name: {test_name}\n"
+                ":description: Chimera test - ChiGen\n"
+                ":tags: chimera\n"
+                ":type: parsing\n"
+                "*/\n")
+
+            with open(filename, 'w') as f:
+                f.write(header + verilog_code)
+
+            print(f"    Test {test_name} added to {output_dir}")
+            success += 1
+
+        except Exception as e:
+            print(f"    Test {test_name} error: {e}")
             failed += 1
-            continue
 
-        verilog_code = result.stdout
+    print(f"Done. Success: {success}, Failed: {failed}")
 
-        header = (
-            "/*\n"
-            f":name: {test_name}\n"
-            ":description: Randomly generated Chimera test\n"
-            ":tags: chimera\n"
-            ":type: parsing\n"
-            "*/\n")
 
-        with open(filename, 'w') as f:
-            f.write(header + verilog_code)
+if (ChiGen):
+    ChiGen()
 
-        print(f"    Test {test_name} added to {output_dir}")
-        success += 1
-
-    except Exception as e:
-        print(f"    Test {test_name} error: {e}")
-        failed += 1
-
-print(f"Done. Success: {success}, Failed: {failed}")
+if (ChiBench):
+    ChiBench()

--- a/generators/chimera
+++ b/generators/chimera
@@ -23,6 +23,21 @@ except KeyError:
 ChiGen = True
 ChiBench = True
 
+header_ChiGen = """/*
+:name: {name}
+:description: Imported test case from ChiGen
+:tags: chimera
+:type: parsing
+*/
+"""
+
+header_ChiBench = """/*
+:name: {name}
+:description: Imported test case from ChiBench
+:tags: chimera
+:type: parsing
+*/
+"""
 subdir = 'chimera'
 
 chimera_root = os.path.join(third_party_dir, 'tests', 'chimera')
@@ -31,13 +46,6 @@ output_dir = os.path.join(tests_dir, 'generated', subdir)
 
 def ChiBench():
 
-    header_templ = """/*
-    :name: {name}
-    :description: Imported test case from ChiBench
-    :tags: chimera
-    :type: parsing
-    */
-    """
     os.makedirs(output_dir, exist_ok=True)
     limit = 5
     count = 0
@@ -52,7 +60,7 @@ def ChiBench():
         with open(f, 'r') as source_file:
             content = source_file.read()
         with open(output_file, "w") as dest_file:
-            dest_file.write(header_templ.format(name=test_name))
+            dest_file.write(header_ChiBench.format(name=test_name))
             dest_file.write(content)
 
         count += 1
@@ -61,13 +69,6 @@ def ChiBench():
 
 def ChiGen():
 
-    header_templ = """/*
-    :name: {name}
-    :description: Imported test case from ChiGen
-    :tags: chimera
-    :type: parsing
-    */
-    """
     os.makedirs(output_dir, exist_ok=True)
     limit = 5
     count = 0
@@ -82,7 +83,7 @@ def ChiGen():
         with open(f, 'r') as source_file:
             content = source_file.read()
         with open(output_file, "w") as dest_file:
-            dest_file.write(header_templ.format(name=test_name))
+            dest_file.write(header_ChiGen.format(name=test_name))
             dest_file.write(content)
 
         count += 1

--- a/generators/chimera
+++ b/generators/chimera
@@ -43,11 +43,10 @@ subdir = 'chimera'
 chimera_root = os.path.join(third_party_dir, 'tests', 'chimera')
 output_dir = os.path.join(tests_dir, 'generated', subdir)
 
-
-def ChiBench():
+if (run_ChiBench):
 
     os.makedirs(output_dir, exist_ok=True)
-    limit = 5
+    limit = 50
     count = 0
     for f in glob.glob(os.path.join(chimera_root, "3k_programs_for_bugs",
                                     "chibench", '*.v')):
@@ -57,20 +56,20 @@ def ChiBench():
         filename = os.path.basename(f)
         test_name = os.path.splitext(filename)[0]
         output_file = os.path.join(output_dir, test_name + '.v')
-        with open(f, 'r') as source_file:
+        with open(f, 'rb') as source_file:
             content = source_file.read()
-        with open(output_file, "w") as dest_file:
-            dest_file.write(header_ChiBench.format(name=test_name))
+        with open(output_file, "wb") as dest_file:
+            dest_file.write(
+                header_ChiBench.format(name=test_name).encode('utf-8'))
             dest_file.write(content)
 
         count += 1
     print(f"Copied {count} ChiBench tests to {output_dir}")
 
-
-def ChiGen():
+if (run_ChiGen):
 
     os.makedirs(output_dir, exist_ok=True)
-    limit = 5
+    limit = 50
     count = 0
     for f in glob.glob(os.path.join(chimera_root, "3k_programs_for_bugs",
                                     "chigen", '*.v')):
@@ -80,84 +79,14 @@ def ChiGen():
         filename = os.path.basename(f)
         test_name = os.path.splitext(filename)[0]
         output_file = os.path.join(output_dir, test_name + '.v')
-        with open(f, 'r') as source_file:
+        with open(f, 'rb') as source_file:
             content = source_file.read()
-        with open(output_file, "w") as dest_file:
-            dest_file.write(header_ChiGen.format(name=test_name))
+        with open(output_file, "wb") as dest_file:
+            dest_file.write(
+                header_ChiGen.format(name=test_name).encode('utf-8'))
             dest_file.write(content)
 
         count += 1
     print(f"Copied {count} ChiGen tests to {output_dir}")
     build_dir = os.path.join(chimera_root, 'build')
     chimera_bin = os.path.join(chimera_root, 'build', 'Chimera')
-
-    return  # skiping the manual genration
-
-    if not os.path.exists(chimera_bin):
-        print("Chimera binary not found. Building Chimera...")
-
-        os.makedirs(build_dir, exist_ok=True)
-
-        try:
-            subprocess.check_call(['cmake', '../src'], cwd=build_dir)
-            subprocess.check_call(['make', 'Chimera'], cwd=build_dir)
-            print("Chimera built successfully.")
-        except subprocess.CalledProcessError as e:
-            print(f"Error building Chimera: {e}")
-            sys.exit(1)
-    else:
-        print(f"Chimera binary found at {chimera_bin}")
-    os.makedirs(output_dir, exist_ok=True)
-
-    print(f"ChiGen : Generating tests in {output_dir}...")
-
-    success = 0
-    failed = 0
-
-    json_files = os.listdir(os.path.join(chimera_root, 'json'))
-    json_files.sort()
-    json_files = json_files[0:1]  # as genration take time this for now
-
-    for json_file in json_files:
-        print(f"  genrating test for {chimera_root}/{json_file} grammer file")
-        test_name = f"ChiGen_{json_file}"
-        filename = os.path.join(output_dir, f"{test_name}.sv")
-
-        cmd = [chimera_bin, os.path.join(chimera_root, 'json', json_file), "1"]
-
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True)
-
-            if result.returncode != 0:
-                print(f"    Test for {json_file} failed to generate")
-                failed += 1
-                continue
-
-            verilog_code = result.stdout
-
-            header = (
-                "/*\n"
-                f":name: {test_name}\n"
-                ":description: Chimera test - ChiGen\n"
-                ":tags: chimera\n"
-                ":type: parsing\n"
-                "*/\n")
-
-            with open(filename, 'w') as f:
-                f.write(header + verilog_code)
-
-            print(f"    Test {test_name} added to {output_dir}")
-            success += 1
-
-        except Exception as e:
-            print(f"    Test {test_name} error: {e}")
-            failed += 1
-
-    print(f"Done. Success: {success}, Failed: {failed}")
-
-
-if (run_ChiGen):
-    ChiGen()
-
-if (run_ChiBench):
-    ChiBench()

--- a/generators/chimera
+++ b/generators/chimera
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+import os
+import sys
+import subprocess
+
+try:
+    tests_dir = os.environ['TESTS_DIR']
+    third_party_dir = os.environ['THIRD_PARTY_DIR']
+except KeyError:
+    print("Export the TESTS_DIR and THIRD_PARTY_DIR variables first")
+    sys.exit(1)
+
+subdir = 'chimera'
+
+chimera_root = os.path.join(third_party_dir, 'tests', 'chimera')
+
+build_dir = os.path.join(chimera_root, 'build')
+
+if not os.path.exists(chimera_bin):
+    print("Chimera binary not found. Building Chimera...")
+
+    os.makedirs(build_dir, exist_ok=True)
+
+    try:
+        subprocess.check_call(['cmake', '../src'], cwd=build_dir)
+        subprocess.check_call(['make', 'Chimera'], cwd=build_dir)
+        print("Chimera built successfully.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error building Chimera: {e}")
+        sys.exit(1)
+else:
+    print(f"Chimera binary found at {chimera_bin}")
+output_dir = os.path.join(tests_dir, 'generated', subdir)
+os.makedirs(output_dir, exist_ok=True)
+
+print(f"Generating tests in {output_dir}...")
+
+chimera_bin = os.path.join(chimera_root, 'build', 'Chimera')
+
+success = 0
+failed = 0
+
+json_files = os.listdir(os.path.join(chimera_root, 'json'))
+json_files.sort()
+
+for json_file in json_files:
+    print(f"  genrating test for {chimera_root}/{json_file} grammer file")
+    test_name = f"chimera_{json_file}"
+    filename = os.path.join(output_dir, f"{test_name}.sv")
+
+    cmd = [chimera_bin, os.path.join(chimera_root, 'json', json_file), "1"]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True)
+
+        if result.returncode != 0:
+            print(f"    Test for {json_file} failed to generate")
+            failed += 1
+            continue
+
+        verilog_code = result.stdout
+
+        header = (
+            "/*\n"
+            f":name: {test_name}\n"
+            ":description: Randomly generated Chimera test\n"
+            ":tags: chimera\n"
+            ":type: parsing\n"
+            "*/\n")
+
+        with open(filename, 'w') as f:
+            f.write(header + verilog_code)
+
+        print(f"    Test {test_name} added to {output_dir}")
+        success += 1
+
+    except Exception as e:
+        print(f"    Test {test_name} error: {e}")
+        failed += 1
+
+print(f"Done. Success: {success}, Failed: {failed}")

--- a/generators/chimera
+++ b/generators/chimera
@@ -38,6 +38,7 @@ def ChiBench():
     :type: parsing
     */
     """
+    os.makedirs(output_dir, exist_ok=True)
     limit = 5
     count = 0
     for f in glob.glob(os.path.join(chimera_root, "3k_programs_for_bugs",
@@ -67,6 +68,7 @@ def ChiGen():
     :type: parsing
     */
     """
+    os.makedirs(output_dir, exist_ok=True)
     limit = 5
     count = 0
     for f in glob.glob(os.path.join(chimera_root, "3k_programs_for_bugs",

--- a/generators/chimera
+++ b/generators/chimera
@@ -25,6 +25,7 @@ subdir = 'chimera'
 chimera_root = os.path.join(third_party_dir, 'tests', 'chimera')
 
 build_dir = os.path.join(chimera_root, 'build')
+chimera_bin = os.path.join(chimera_root, 'build', 'Chimera')
 
 if not os.path.exists(chimera_bin):
     print("Chimera binary not found. Building Chimera...")
@@ -45,7 +46,7 @@ os.makedirs(output_dir, exist_ok=True)
 
 print(f"Generating tests in {output_dir}...")
 
-chimera_bin = os.path.join(chimera_root, 'build', 'Chimera')
+
 
 success = 0
 failed = 0


### PR DESCRIPTION
### Adding chimera to sv-test
* added generator script.
* added cmake to ci-test as it is dependency to make chimera.

currently the script can generate the testcases after making the chimera and it can also copy the testcases form `chimera/3k_programs_for_bugs`. 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds Chimera tests to sv-test suite with a generator script, updates CI for CMake, and includes new submodule for Chimera.
> 
>   - **Chimera Tests**:
>     - Adds `generators/chimera` script to generate test cases from Chimera's `3k_programs_for_bugs`.
>     - Copies up to 50 test cases each from `chibench` and `chigen` directories.
>   - **Submodules**:
>     - Adds `third_party/tests/chimera` submodule pointing to `https://github.com/Silimate/chimera.git`.
>   - **Makefile**:
>     - Updates `TESTS` variable to include `.v` files in addition to `.sv` files.
>   - **CI Configuration**:
>     - Adds CMake installation step in `sv-tests-ci.yml` to support Chimera build.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2Fsv-tests&utm_source=github&utm_medium=referral)<sup> for b722f00125d91cfdd085c0bac2ef5acc9b48d78e. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->